### PR TITLE
Removed special character in authors name

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,6 +1,6 @@
 name    'netmanagers-tcpwrappers'
 version '1.0.0'
-author  'Javier Bértoli'
+author  'Javier Bertoli'
 license 'Apache2'
 project_page 'http://www.netmanagers.com'
 source  'https://github.com/netmanagers/puppet-tcpwrappers'


### PR DESCRIPTION
The special character is breaking Puppet:
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: "\xC3" on US-ASCII at .....
